### PR TITLE
Correction sur l'index du cookie de session

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = class {
     this.log("Authenticating..")
     this.req("GET", "https://www.mon-compte.bouyguestelecom.fr/cas/login", {}, (response, body) => {
 
-      var jsessionid = response.headers["set-cookie"][0].match(/JSESSIONID=(.*); Path=\/cas\/; HttpOnly/)
+      var jsessionid = response.headers["set-cookie"][1].match(/JSESSIONID=(.*); Path=\/cas\/; HttpOnly/)
       var lt = body.match(/<input type=\"hidden\" name=\"lt\" value=\"([a-zA-Z0-9_-]*)\"/);
 
       if(jsessionid == null && lt == null) cb({ code: "LOGIN_UNKNOWN" });


### PR DESCRIPTION
Bonjour,
Suite à la mise à jour du site Bouygues, votre api d'envoi de sms ne fonctionnait plus.
Voici donc un correctif. Il s'agissait de l'index du cookie de session qui a changé.

Cordialement,